### PR TITLE
Included bug demo script. (Also, added setcellembed! and celldata functions.)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.jl.cov
 *.jl.mem
+*.jl.orig

--- a/src/GeneralizedMaps.jl
+++ b/src/GeneralizedMaps.jl
@@ -277,10 +277,8 @@ Traverse the input orbit starting at start and applying the function f.
 Returns all the unique darts seen during traversal
 """ ->
 function traverse{T,S}(orbit::Orbit, start::Dart{T,S}, f::Function)
-    seen = Set()
-    seenlist = []
+    seen = []
     push!(seen, start)
-    push!(seenlist, start)
     f(start)
     function traverseWorker( orbit::Orbit, start::Dart, func::Function )
         for j in Task(orbit.index)
@@ -290,20 +288,17 @@ function traverse{T,S}(orbit::Orbit, start::Dart{T,S}, f::Function)
 		if ! in(get(next), seen)
 		    func(get(next))
 		    push!(seen, get(next))
-                    push!(seenlist, get(next))
                 end
                 continue
             else
 		if ! in(get(next), seen)
 		    func(get(next))
 		    push!(seen, get(next))
-                    push!(seenlist, get(next))
 		    traverseWorker(orbit, get(next), func)
 		end
             end
         end
-        # return seen
-	return seenlist
+        return seen
     end
     return traverseWorker(orbit, start, f)
 end
@@ -467,7 +462,7 @@ end
 function collectkcells(g::GeneralizedMap, k)
     cells = Set() #cells = Set{Set{eltype(g.darts)[2]}}()
     for (i, d) in g.darts
-        darts = collectcelldarts(d, k)
+        darts = Set(collectcelldarts(d, k))
         if length(darts) > k
             push!(cells, darts)
         end

--- a/src/GeneralizedMaps.jl
+++ b/src/GeneralizedMaps.jl
@@ -278,29 +278,34 @@ Returns all the unique darts seen during traversal
 """ ->
 function traverse{T,S}(orbit::Orbit, start::Dart{T,S}, f::Function)
     seen = Set()
-    push!( seen, start )
-    f( start )
+    seenlist = []
+    push!(seen, start)
+    push!(seenlist, start)
+    f(start)
     function traverseWorker( orbit::Orbit, start::Dart, func::Function )
         for j in Task(orbit.index)
-			next = start.alpha[j + 1]
+	    next = start.alpha[j + 1]
             if isnull(next)
                 next = Nullable(start)
-			    if ! in( get(next), seen )
-				    func( get(next) )
-				    push!( seen, get(next) )
+		if ! in(get(next), seen)
+		    func(get(next))
+		    push!(seen, get(next))
+                    push!(seenlist, get(next))
                 end
                 continue
             else
-			    if ! in( get(next), seen )
-				    func( get(next) )
-				    push!( seen, get(next) )
-				    traverseWorker( orbit, get(next), func)
-			    end
+		if ! in(get(next), seen)
+		    func(get(next))
+		    push!(seen, get(next))
+                    push!(seenlist, get(next))
+		    traverseWorker(orbit, get(next), func)
+		end
             end
         end
-	return seen
+        # return seen
+	return seenlist
     end
-    return traverseWorker(orbit, start, f )
+    return traverseWorker(orbit, start, f)
 end
 
 Docile.@doc """

--- a/src/GeneralizedMaps.jl
+++ b/src/GeneralizedMaps.jl
@@ -278,8 +278,8 @@ Returns all the unique darts seen during traversal
 """ ->
 function traverse{T,S}(orbit::Orbit, start::Dart{T,S}, f::Function)
     seen = Set()
-	#push!( seen, start )
-	#f( start )
+    push!( seen, start )
+    f( start )
     function traverseWorker( orbit::Orbit, start::Dart, func::Function )
         for j in Task(orbit.index)
 			next = start.alpha[j + 1]
@@ -298,7 +298,7 @@ function traverse{T,S}(orbit::Orbit, start::Dart{T,S}, f::Function)
 			    end
             end
         end
-		return seen
+	return seen
     end
     return traverseWorker(orbit, start, f )
 end
@@ -439,6 +439,24 @@ function polygon!{I, T, S}(g::GeneralizedMap{I, T, S}, dim, n)
         sew!(newdarts[i], newdarts[(i+1) % (2*n)], 1)
     end
     return newdarts
+end
+
+
+function parallelepiped!{I, T, S}(g::GeneralizedMap{I, T, S}, dim)
+    for i in 1:6
+        polygon!(g, dim, 4)
+    end
+    # for i in 0:3
+    #     println(2i+1, " ", 8i+17)
+    #     println(2i+9, " ", 8i+22)
+    #     println(8i+19, " ", mod1(8(i+2), 32)+16)
+    # end
+    # sew!(g.darts[1], g.darts[17], 2)
+    for i in 0:3
+        sew!(g.darts[2i+1], g.darts[8i+17], 2)
+        sew!(g.darts[2i+9], g.darts[8i+22], 2)
+        sew!(g.darts[8i+19], g.darts[mod1(8(i+2), 32)+16], 2)
+    end
 end
 
 function collectkcells(g::GeneralizedMap, k)

--- a/src/GeneralizedMaps.jl
+++ b/src/GeneralizedMaps.jl
@@ -1,7 +1,7 @@
 module GeneralizedMaps
 using Docile
 
-export OrientedDart, Dart, id, ids, GeneralizedMap, sew, collectcelldarts, collectkcells, countkcells, Orbit, OrbitBut, polygon!, data, setcellembed!
+export OrientedDart, Dart, id, ids, GeneralizedMap, sew, collectcelldarts, collectkcells, countkcells, Orbit, OrbitBut
 
 type OrientedDart{T, S}
     index::T

--- a/src/GeneralizedMaps.jl
+++ b/src/GeneralizedMaps.jl
@@ -342,6 +342,9 @@ function dispatchembedding!{T,S}(start::Dart{T,S}, dim, loc::Dart{T,S})
     OrbitButForEach( start, dim, (d) -> setembedloc!(d, dim, loc) )
 end
 
+Docile.@doc """
+Embeds data into specified key dart for the i-cell and sets the key dart as embedloc for itself and all other darts in the i-cell.
+""" -> 
 function setcellembed!{T,S}(keydart::Dart{T,S}, i, data)
     setembed!(keydart, i, Nullable{S}(data))
     dispatchembedding!(keydart, i, keydart)
@@ -350,7 +353,7 @@ end
 function sharecopyembedding{T,S}(d1::Dart{T,S}, d2::Dart{T,S}, dim)
     function copy_embed( ds, dd )
         setembed!(dd, dim, ds.globalembed[dim+1])
-        dispatchembedding(dd, dim, dd)
+        dispatchembedding!(dd, dim, dd)
     end
     k1 = findcellkey(d1, dim)
     k2 = findcellkey(d2, dim)
@@ -359,11 +362,11 @@ function sharecopyembedding{T,S}(d1::Dart{T,S}, d2::Dart{T,S}, dim)
 		    #FIXME is this a bug?
             new_em = d2.globalembed[dim+1]
             setembed!(d1, dim, new_em)
-            dispatchembedding(d1, dim, d1)
+            dispatchembedding!(d1, dim, d1)
         else
             new_em = d2.globalembed[dim+1]
             setembed!(d2, dim, new_em)
-            dispatchembedding(d2, dim, d2)
+            dispatchembedding!(d2, dim, d2)
         end
     end
 end
@@ -378,10 +381,10 @@ function sew!{T, S}(d1::Dart{T, S}, d2::Dart{T, S}, dim)
             k2 = findcellkey(dp2, i)
             if !isequal(k1, k2)
                 if !isnull(k1)
-                    dispatchembedding(dp2, i, get(get(k1).embedloc[i+1]))
+                    dispatchembedding!(dp2, i, get(get(k1).embedloc[i+1]))
                 else
                     if !isnull(k2)
-                        dispatchembedding(dp1, i, get(get(k2).embedloc[i+1]))
+                        dispatchembedding!(dp1, i, get(get(k2).embedloc[i+1]))
                     end
                 end
             end
@@ -402,10 +405,10 @@ function orientedsew!{T, S}(d1::OrientedDart{T, S}, d2::OrientedDart{T, S}, dim)
             k2 = findcellkey(dp2, i)
             if !isequal(k1, k2)
                 if !isnull(k1)
-                    dispatchembedding(dp2, i, get(get(k1).embedloc[i+1]))
+                    dispatchembedding!(dp2, i, get(get(k1).embedloc[i+1]))
                 else
                     if !isnull(k2)
-                        dispatchembedding(dp1, i, get(get(k2).embedloc[i+1]))
+                        dispatchembedding!(dp1, i, get(get(k2).embedloc[i+1]))
                     end
                 end
             end

--- a/src/GeneralizedMaps.jl
+++ b/src/GeneralizedMaps.jl
@@ -139,6 +139,13 @@ Docile.@doc """
 Get the embedded data for dimension i of this dart.
 """ ->
 function data{T, S}(d::Union(Dart{T, S}, OrientedDart{T,S}), i)
+    return get(d.globalembed[i+1])
+end
+
+Docile.@doc """
+Get the embedded data for i-cell containing this dart.
+""" ->
+function celldata{T, S}(d::Union(Dart{T, S}, OrientedDart{T,S}), i)
     key = get(d.embedloc[i+1])
     return(get(key.globalembed[i+1]))
 end
@@ -338,7 +345,7 @@ function findcellkey{T,S}(start::Dart{T,S}, dim)
     return start.embedloc[dim+1]
 end
 
-function dispatchembedding!{T,S}(start::Dart{T,S}, dim, loc::Dart{T,S})
+function dispatchembedding{T,S}(start::Dart{T,S}, dim, loc::Dart{T,S})
     OrbitButForEach( start, dim, (d) -> setembedloc!(d, dim, loc) )
 end
 
@@ -347,13 +354,13 @@ Embeds data into specified key dart for the i-cell and sets the key dart as embe
 """ -> 
 function setcellembed!{T,S}(keydart::Dart{T,S}, i, data)
     setembed!(keydart, i, Nullable{S}(data))
-    dispatchembedding!(keydart, i, keydart)
+    dispatchembedding(keydart, i, keydart)
 end
     
 function sharecopyembedding{T,S}(d1::Dart{T,S}, d2::Dart{T,S}, dim)
     function copy_embed( ds, dd )
         setembed!(dd, dim, ds.globalembed[dim+1])
-        dispatchembedding!(dd, dim, dd)
+        dispatchembedding(dd, dim, dd)
     end
     k1 = findcellkey(d1, dim)
     k2 = findcellkey(d2, dim)
@@ -362,11 +369,11 @@ function sharecopyembedding{T,S}(d1::Dart{T,S}, d2::Dart{T,S}, dim)
 		    #FIXME is this a bug?
             new_em = d2.globalembed[dim+1]
             setembed!(d1, dim, new_em)
-            dispatchembedding!(d1, dim, d1)
+            dispatchembedding(d1, dim, d1)
         else
             new_em = d2.globalembed[dim+1]
             setembed!(d2, dim, new_em)
-            dispatchembedding!(d2, dim, d2)
+            dispatchembedding(d2, dim, d2)
         end
     end
 end
@@ -381,10 +388,10 @@ function sew!{T, S}(d1::Dart{T, S}, d2::Dart{T, S}, dim)
             k2 = findcellkey(dp2, i)
             if !isequal(k1, k2)
                 if !isnull(k1)
-                    dispatchembedding!(dp2, i, get(get(k1).embedloc[i+1]))
+                    dispatchembedding(dp2, i, get(get(k1).embedloc[i+1]))
                 else
                     if !isnull(k2)
-                        dispatchembedding!(dp1, i, get(get(k2).embedloc[i+1]))
+                        dispatchembedding(dp1, i, get(get(k2).embedloc[i+1]))
                     end
                 end
             end
@@ -405,10 +412,10 @@ function orientedsew!{T, S}(d1::OrientedDart{T, S}, d2::OrientedDart{T, S}, dim)
             k2 = findcellkey(dp2, i)
             if !isequal(k1, k2)
                 if !isnull(k1)
-                    dispatchembedding!(dp2, i, get(get(k1).embedloc[i+1]))
+                    dispatchembedding(dp2, i, get(get(k1).embedloc[i+1]))
                 else
                     if !isnull(k2)
-                        dispatchembedding!(dp1, i, get(get(k2).embedloc[i+1]))
+                        dispatchembedding(dp1, i, get(get(k2).embedloc[i+1]))
                     end
                 end
             end

--- a/test/traverse_test.jl
+++ b/test/traverse_test.jl
@@ -1,0 +1,24 @@
+using GeneralizedMaps: polygon!, GeneralizedMap, collectcelldarts, Dart
+
+# Initialized empty GMap.
+g = GeneralizedMap(Dict{Int64, Dart{Int64, Int64}}());
+
+n = 4
+# Create four independent polygons in g.
+for i in 1:n
+    polygon!(g, 1, 4);
+end
+
+for i in 1:n
+    println("Ploygon: ", i)
+    print("Dart ", i*8-7, " traversal:\n")
+    for d in collectcelldarts(g.darts[i*8-7], 0)
+        print(d.index, " ")
+    end
+    println()
+    print("Dart ", i*8, " traversal:\n")
+    for d in collectcelldarts(g.darts[i*8], 0)
+        print(d.index, " ")
+    end
+    println()
+end

--- a/test/traverse_test.jl
+++ b/test/traverse_test.jl
@@ -9,6 +9,9 @@ for i in 1:n
     polygon!(g, 1, 4);
 end
 
+# Show the return of collect cell darts using both darts in the
+# 0-cell as the start dart. Repeat for one 0-cell on each of the
+# four polygons to see patterns (or the lack thereof).
 for i in 1:n
     println("Ploygon: ", i)
     print("Dart ", i*8-7, " traversal:\n")

--- a/test/traverse_test.jl
+++ b/test/traverse_test.jl
@@ -12,7 +12,7 @@ for i in 1:n
     polygon!(g, 1, dim_max);
 end
 
-facts("Check that traverse always returns the start dart first. (Uses collectcelldarts to call traverse.)") do
+facts("Check that traverse always returns the start dart first. Uses collectcelldarts to call traverse.") do
     for (i, dart) in g.darts
         for dim in 0:dim_max
             t = collectcelldarts(dart, dim)

--- a/test/traverse_test.jl
+++ b/test/traverse_test.jl
@@ -1,27 +1,39 @@
 using GeneralizedMaps: polygon!, GeneralizedMap, collectcelldarts, Dart
+using FactCheck
+
 
 # Initialized empty GMap.
 g = GeneralizedMap(Dict{Int64, Dart{Int64, Int64}}());
 
-n = 4
-# Create four independent polygons in g.
+# Create n independent squares in g.
+n=4
+dim_max=2
 for i in 1:n
-    polygon!(g, 1, 4);
+    polygon!(g, 1, dim_max);
+end
+
+facts("Check that traverse always returns the start dart first. (Uses collectcelldarts to call traverse.)") do
+    for (i, dart) in g.darts
+        for dim in 0:dim_max
+            t = collectcelldarts(dart, dim)
+            @fact dart => t[1]
+        end
+    end
 end
 
 # Show the return of collect cell darts using both darts in the
 # 0-cell as the start dart. Repeat for one 0-cell on each of the
 # four polygons to see patterns (or the lack thereof).
-for i in 1:n
-    println("Ploygon: ", i)
-    print("Dart ", i*8-7, " traversal:\n")
-    for d in collectcelldarts(g.darts[i*8-7], 0)
-        print(d.index, " ")
-    end
-    println()
-    print("Dart ", i*8, " traversal:\n")
-    for d in collectcelldarts(g.darts[i*8], 0)
-        print(d.index, " ")
-    end
-    println()
-end
+# for i in 1:n
+#     println("Ploygon: ", i)
+#     print("Dart ", i*8-7, " traversal:\n")
+#     for d in collectcelldarts(g.darts[i*8-7], 0)
+#         print(d.index, " ")
+#     end
+#     println()
+#     print("Dart ", i*8, " traversal:\n")
+#     for d in collectcelldarts(g.darts[i*8], 0)
+#         print(d.index, " ")
+#     end
+#     println()
+# end


### PR DESCRIPTION
There were a few interesting indentations that I was wondering if they were intentional and part of some julia style guidelines of which I'm not aware. I've removed them here, but if they were intentional, I'd like to learn why.

Originally, I replaced your data function with celldata, but I decided to keep both in case you needed the original. It seems in most cases (anytime dispatchembedding is used) a dart's embedloc will be pointing to itself if it is the key cell, so celldata should work on getting the embedded data from anything but a lone dart.
